### PR TITLE
Suggested Improvements to the Slides- Carlos Paz y Mino

### DIFF
--- a/02-lab/slides.md
+++ b/02-lab/slides.md
@@ -94,7 +94,7 @@ AMPL has two types of commands, i.e., a set of commands
 
 ### Model files
 
-Throughout this course we assume that the commands to formulate a model are stored in a separate model file with suffix `.mod`.
+Throughout this course we assume that the commands to formulate a model are stored in a separate model file with suffix `.mod` or `.txt` .
 
 > [!TIP]
 > In your AMPL installation folder, you can find several examples of such model files. These can be opened and modified with any text editor.
@@ -134,7 +134,8 @@ x2 = 6
 ```
 
 - The model is loaded with the command `model`.
-- The problem is solved with the command `solve`.
+- The problem is solved with the command `solve`
+- In case you get an error please use the command `option solver highs` and in the next line the solve command 
 - The solution can be shown with the command `display`.
 - Whenever we change the model, we must tell AMPL to `reset` before we load the model. 
 


### PR DESCRIPTION
Dear Professor Asvin,

I’ve identified a few areas where the slides could be clarified to improve understanding. I’ve also attached screenshots showing my suggested corrections.

1. It would be helpful to state explicitly that x and y are greater than or equal to zero in this slide.
2. In this section, since it only mentions “mod,” many of us were confused. Adding that “.txt” is also a valid format would make it clearer.
3. Finally, we should mention the solver = 'highs' option in this window, as most of us couldn’t get it to work with just the solve() command.

Thank you very much for your time and for considering these suggestions.

Best regards,

<img width="918" height="177" alt="image" src="https://github.com/user-attachments/assets/b594d1c4-51ca-4a4b-9203-ac4eaf08d988" />
..
.
.
<img width="1337" height="322" alt="image" src="https://github.com/user-attachments/assets/6c19a8a8-55ac-461b-b211-2e883b2835f8" />

.
.
.
<img width="1301" height="497" alt="image" src="https://github.com/user-attachments/assets/95c92569-2b8e-4990-87a9-ca4b91c6348e" />

